### PR TITLE
feat: adding support for AWS CLI v2.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,33 @@ LABEL repository="https://github.com/falnyr/aws-sam-deploy-action"
 LABEL homepage="https://github.com/falnyr/aws-sam-deploy-action"
 LABEL maintainer="Jan Richter <falnyr@gmail.com>"
 
-RUN apk update && apk add -qU bash aws-cli --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
+ENV GLIBC_VER=2.31-r0
+
+# install glibc compatibility for alpine
+RUN apk --no-cache add \
+        binutils \
+        curl \
+    && curl -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
+    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-${GLIBC_VER}.apk \
+    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk \
+    && apk add --no-cache \
+        glibc-${GLIBC_VER}.apk \
+        glibc-bin-${GLIBC_VER}.apk \
+    && curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip \
+    && unzip awscliv2.zip \
+    && aws/install \
+    && rm -rf \
+        awscliv2.zip \
+        aws \
+        /usr/local/aws-cli/v2/*/dist/aws_completer \
+        /usr/local/aws-cli/v2/*/dist/awscli/data/ac.index \
+        /usr/local/aws-cli/v2/*/dist/awscli/examples \
+    && apk --no-cache del \
+        binutils \
+        curl \
+    && rm glibc-${GLIBC_VER}.apk \
+    && rm glibc-bin-${GLIBC_VER}.apk \
+    && rm -rf /var/cache/apk/*
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Since the package manager's version is outdated (https://pkgs.alpinelinux.org/packages?name=aws-cli&branch=edge), adding a custom aws cli v2 installation.

Should be a solution for #1 .