### PR TITLE
Add bucket on deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This action is forked from [r0zar/sam-deploy-action](https://github.com/r0zar/sa
 
 ```yml
 name: "Deploy SAM Stack to Production"
-on: 
+on:
   push:
     branches:
     - master
@@ -45,6 +45,8 @@ jobs:
 * `AWS_SECRET_ACCESS_KEY` - [**Required**]. AWS Secret Access Key.
   * Type: `string`
 * `AWS_DEPLOY_BUCKET` - [**Required**]. AWS S3 Bucket where the Stack package is going to be stored.
+  * Type: `string`
+* `AWS_PACKAGE_BUCKET` - [**Required**]. AWS S3 Bucket where the Stack template is going to be stored.
   * Type: `string`
 * `AWS_BUCKET_PREFIX` - [Optional]. S3 Bucket's folder where to upload the package.
   * Type: `string`

--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ jobs:
   * Type: `string`
 * `AWS_DEPLOY_BUCKET` - [**Required**]. AWS S3 Bucket where the Stack package is going to be stored.
   * Type: `string`
-* `AWS_PACKAGE_BUCKET` - [**Required**]. AWS S3 Bucket where the Stack template is going to be stored.
-  * Type: `string`
 * `AWS_BUCKET_PREFIX` - [Optional]. S3 Bucket's folder where to upload the package.
   * Type: `string`
 * `FORCE_UPLOAD` - [Optional]. Whether to override existing packages in case they are an exact match.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,6 +38,11 @@ if [[ -z "$AWS_DEPLOY_BUCKET" ]]; then
     exit 1
 fi
 
+if [[ -z "$AWS_PACKAGE_BUCKET" ]]; then
+    echo AWS Package Bucket invalid
+    exit 1
+fi
+
 if [[ ! -z "$AWS_BUCKET_PREFIX" ]]; then
     AWS_BUCKET_PREFIX="--s3-prefix ${AWS_BUCKET_PREFIX}"
 fi
@@ -82,4 +87,4 @@ output = text
 region = $AWS_REGION" > ~/.aws/config
 
 aws cloudformation package --template-file $TEMPLATE --output-template-file serverless-output.yaml --s3-bucket $AWS_DEPLOY_BUCKET $AWS_BUCKET_PREFIX $FORCE_UPLOAD $USE_JSON
-aws cloudformation deploy --template-file serverless-output.yaml --stack-name $AWS_STACK_NAME $CAPABILITIES $PARAMETER_OVERRIDES $TAGS $NO_FAIL_EMPTY_CHANGESET
+aws cloudformation deploy --template-file serverless-output.yaml --stack-name $AWS_STACK_NAME --s3-bucket $AWS_PACKAGE_BUCKET $CAPABILITIES $PARAMETER_OVERRIDES $TAGS $NO_FAIL_EMPTY_CHANGESET

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,11 +38,6 @@ if [[ -z "$AWS_DEPLOY_BUCKET" ]]; then
     exit 1
 fi
 
-if [[ -z "$AWS_PACKAGE_BUCKET" ]]; then
-    echo AWS Package Bucket invalid
-    exit 1
-fi
-
 if [[ ! -z "$AWS_BUCKET_PREFIX" ]]; then
     AWS_BUCKET_PREFIX="--s3-prefix ${AWS_BUCKET_PREFIX}"
 fi
@@ -87,4 +82,4 @@ output = text
 region = $AWS_REGION" > ~/.aws/config
 
 aws cloudformation package --template-file $TEMPLATE --output-template-file serverless-output.yaml --s3-bucket $AWS_DEPLOY_BUCKET $AWS_BUCKET_PREFIX $FORCE_UPLOAD $USE_JSON
-aws cloudformation deploy --template-file serverless-output.yaml --stack-name $AWS_STACK_NAME --s3-bucket $AWS_PACKAGE_BUCKET $CAPABILITIES $PARAMETER_OVERRIDES $TAGS $NO_FAIL_EMPTY_CHANGESET
+aws cloudformation deploy --template-file serverless-output.yaml --stack-name $AWS_STACK_NAME --s3-bucket $AWS_DEPLOY_BUCKET $CAPABILITIES $PARAMETER_OVERRIDES $TAGS $NO_FAIL_EMPTY_CHANGESET


### PR DESCRIPTION
Fix deploy a template larger than 51,200 bytes with the command `aws cloudformation deploy`.

--s3-bucket: The URI of the Amazon S3 bucket where this command uploads your AWS CloudFormation template. This is required to deploy templates that are larger than 51,200 bytes.

AWS documentation: https://docs.aws.amazon.com/cli/latest/reference/cloudformation/deploy/index.html#deploy

